### PR TITLE
add options to settings, for html icon recognization in django project

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,14 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "html.format.indentInnerHtml": true,
+    "html.format.indentHandlebars": true,
+    "emmet.includeLanguages": {"django-html": "html"},
+    "[django-html]": {
+
+    },
+    "files.associations": {
+        "*.html": "html"
+    },
 }


### PR DESCRIPTION
HTML files recognized as Django Template in VS Code(version: 1.56.2) , with and problem solved with:
`"emmet.includeLanguages": {"django-html": "html"},
"[django-html]": {

},
"files.associations": {
    "*.html": "html"
}`